### PR TITLE
ViewPager view implementation

### DIFF
--- a/app/src/main/java/com/rizzi/composepdf/BouquetViewModel.kt
+++ b/app/src/main/java/com/rizzi/composepdf/BouquetViewModel.kt
@@ -1,8 +1,11 @@
 package com.rizzi.composepdf
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import com.rizzi.bouquet.HorizontalPdfReaderState
 import com.rizzi.bouquet.PdfReaderState
 import com.rizzi.bouquet.ResourceType
+import com.rizzi.bouquet.VerticalPdfReaderState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -10,9 +13,15 @@ class BouquetViewModel : ViewModel() {
     private val mStateFlow = MutableStateFlow<PdfReaderState?>(null)
     val stateFlow: StateFlow<PdfReaderState?> = mStateFlow
 
+    val switchState = mutableStateOf(false)
+
     fun openResource(resourceType: ResourceType) {
         mStateFlow.tryEmit(
-            PdfReaderState(resourceType, true)
+            if (switchState.value) {
+                HorizontalPdfReaderState(resourceType, true)
+            } else {
+                VerticalPdfReaderState(resourceType, true)
+            }
         )
     }
 

--- a/bouquet/build.gradle.kts
+++ b/bouquet/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.2.1")
     implementation("androidx.compose.material:material:1.2.1")
     implementation("androidx.core:core-ktx:1.9.0")
+    implementation("com.google.accompanist:accompanist-pager:0.26.5-rc")
 }
 
 afterEvaluate {

--- a/bouquet/src/main/java/com/rizzi/bouquet/BouquetPdfRender.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/BouquetPdfRender.kt
@@ -13,7 +13,8 @@ import kotlinx.coroutines.sync.withLock
 internal class BouquetPdfRender(
     private val fileDescriptor: ParcelFileDescriptor,
     val width: Int,
-    val height: Int
+    val height: Int,
+    val portrait: Boolean
 ) {
     private val pdfRenderer = PdfRenderer(fileDescriptor)
     val pageCount get() = pdfRenderer.pageCount
@@ -27,7 +28,8 @@ internal class BouquetPdfRender(
             pdfRenderer = pdfRenderer,
             coroutineScope = coroutineScope,
             width = width,
-            height = height
+            height = height,
+            portrait = portrait
         )
     }
 
@@ -43,16 +45,27 @@ internal class BouquetPdfRender(
         val pdfRenderer: PdfRenderer,
         val coroutineScope: CoroutineScope,
         width: Int,
-        height: Int
+        height: Int,
+        portrait: Boolean
     ) {
         val dimension = pdfRenderer.openPage(index).let {
-            val h = it.height * (width.toFloat() / it.width)
-            val dim = Dimension(
-                height = h.toInt(),
-                width = width
-            )
-            it.close()
-            dim
+            if (portrait) {
+                val h = it.height * (width.toFloat() / it.width)
+                val dim = Dimension(
+                    height = h.toInt(),
+                    width = width
+                )
+                it.close()
+                dim
+            } else {
+                val w = it.width * (height.toFloat() / it.height)
+                val dim = Dimension(
+                    height = height,
+                    width = w.toInt()
+                )
+                it.close()
+                dim
+            }
         }
 
         val stateFlow = MutableStateFlow(createBlankBitmap())

--- a/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
@@ -1,0 +1,57 @@
+package com.rizzi.bouquet
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.core.net.toUri
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.PagerState
+
+@OptIn(ExperimentalPagerApi::class)
+class HorizontalPdfReaderState(
+    resource: ResourceType,
+    isZoomEnable: Boolean = false,
+    internal val pagerState: PagerState = PagerState()
+) : PdfReaderState(resource, isZoomEnable) {
+
+    override val currentPage: Int
+        get() = pagerState.currentPage
+
+    override val isScrolling: Boolean
+        get() = pagerState.isScrollInProgress
+
+    companion object {
+        val Saver: Saver<HorizontalPdfReaderState, *> = listSaver(
+            save = {
+                val resource = it.file?.let { file ->
+                    ResourceType.Local(
+                        file.toUri()
+                    )
+                } ?: it.resource
+                listOf(
+                    resource,
+                    it.isZoomEnable,
+                    it.pagerState.currentPage
+                )
+            },
+            restore = {
+                HorizontalPdfReaderState(
+                    it[0] as ResourceType,
+                    it[1] as Boolean,
+                    PagerState(currentPage = it[2] as Int)
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun rememberHorizontalPdfReaderState(
+    resource: ResourceType,
+    isZoomEnable: Boolean = true
+): HorizontalPdfReaderState {
+    return rememberSaveable(saver = HorizontalPdfReaderState.Saver) {
+        HorizontalPdfReaderState(resource, isZoomEnable)
+    }
+}

--- a/bouquet/src/main/java/com/rizzi/bouquet/PDFImage.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/PDFImage.kt
@@ -24,6 +24,7 @@ internal fun PdfImage(
                 scaleX = gld.scale
                 scaleY = gld.scale
                 translationX = gld.translationX
+                translationY = gld.translationY
             }
     )
 }

--- a/bouquet/src/main/java/com/rizzi/bouquet/PdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/PdfReaderState.kt
@@ -1,17 +1,12 @@
 package com.rizzi.bouquet
 
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.listSaver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import java.io.File
 
-class PdfReaderState(
+abstract class PdfReaderState(
     val resource: ResourceType,
     isZoomEnable: Boolean = false
 ) {
@@ -37,8 +32,6 @@ class PdfReaderState(
     val file: File?
         get() = mFile
 
-    internal var lazyState: LazyListState = LazyListState()
-
     internal var pdfRender by mutableStateOf<BouquetPdfRender?>(null)
 
     internal var mLoadPercent by mutableStateOf(0)
@@ -48,53 +41,15 @@ class PdfReaderState(
     val pdfPageCount: Int
         get() = pdfRender?.pageCount ?: 0
 
-    val currentPage: Int
-        get() = currentPage()
-
-    private fun currentPage(): Int {
-        return pdfRender?.let { pdfRender ->
-            val currentMinIndex = lazyState.firstVisibleItemIndex
-            var lastVisibleIndex = currentMinIndex
-            var totalVisiblePortion =
-                (pdfRender.pageLists[currentMinIndex].dimension.height * scale) - lazyState.firstVisibleItemScrollOffset
-            for (i in currentMinIndex + 1 until pdfPageCount) {
-                val newTotalVisiblePortion =
-                    totalVisiblePortion + (pdfRender.pageLists[i].dimension.height * scale)
-                if (newTotalVisiblePortion <= pdfRender.height) {
-                    lastVisibleIndex = i
-                    totalVisiblePortion = newTotalVisiblePortion
-                } else {
-                    break
-                }
-            }
-            lastVisibleIndex + 1
-        } ?: 0
-    }
+    abstract val currentPage: Int
 
     val isLoaded
         get() = mFile != null
 
-    val isScrolling: Boolean
-        get() = lazyState.isScrollInProgress
+    abstract val isScrolling: Boolean
 
-    companion object {
-        val Saver: Saver<PdfReaderState, *> = listSaver(
-            save = {
-                listOf(it.resource, it.isZoomEnable)
-            },
-            restore = {
-                PdfReaderState(it[0] as ResourceType, it[1] as Boolean)
-            }
-        )
-    }
-}
-
-@Composable
-fun rememberPdfReaderState(
-    resource: ResourceType,
-    isZoomEnable: Boolean = true
-): PdfReaderState {
-    return rememberSaveable(saver = PdfReaderState.Saver) {
-        PdfReaderState(resource, isZoomEnable)
+    fun close() {
+        pdfRender?.close()
+        pdfRender = null
     }
 }

--- a/bouquet/src/main/java/com/rizzi/bouquet/VerticalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/VerticalPdfReaderState.kt
@@ -1,0 +1,79 @@
+package com.rizzi.bouquet
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.core.net.toUri
+
+class VerticalPdfReaderState(
+    resource: ResourceType,
+    isZoomEnable: Boolean = false,
+    internal val lazyState: LazyListState = LazyListState()
+) : PdfReaderState(resource, isZoomEnable) {
+
+    override val currentPage: Int
+        get() = currentPage()
+
+    override val isScrolling: Boolean
+        get() = lazyState.isScrollInProgress
+
+    private fun currentPage(): Int {
+        return pdfRender?.let { pdfRender ->
+            val currentMinIndex = lazyState.firstVisibleItemIndex
+            var lastVisibleIndex = currentMinIndex
+            var totalVisiblePortion =
+                (pdfRender.pageLists[currentMinIndex].dimension.height * scale) - lazyState.firstVisibleItemScrollOffset
+            for (i in currentMinIndex + 1 until pdfPageCount) {
+                val newTotalVisiblePortion =
+                    totalVisiblePortion + (pdfRender.pageLists[i].dimension.height * scale)
+                if (newTotalVisiblePortion <= pdfRender.height) {
+                    lastVisibleIndex = i
+                    totalVisiblePortion = newTotalVisiblePortion
+                } else {
+                    break
+                }
+            }
+            lastVisibleIndex + 1
+        } ?: 0
+    }
+
+    companion object {
+        val Saver: Saver<VerticalPdfReaderState, *> = listSaver(
+            save = {
+                val resource = it.file?.let { file ->
+                    ResourceType.Local(
+                        file.toUri()
+                    )
+                } ?: it.resource
+                listOf(
+                    resource,
+                    it.isZoomEnable,
+                    it.lazyState.firstVisibleItemIndex,
+                    it.lazyState.firstVisibleItemScrollOffset
+                )
+            },
+            restore = {
+                VerticalPdfReaderState(
+                    it[0] as ResourceType,
+                    it[1] as Boolean,
+                    lazyState = LazyListState(
+                        firstVisibleItemIndex = it[2] as Int,
+                        firstVisibleItemScrollOffset = it[3] as Int
+                    )
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun rememberVerticalPdfReaderState(
+    resource: ResourceType,
+    isZoomEnable: Boolean = true
+): VerticalPdfReaderState {
+    return rememberSaveable(saver = VerticalPdfReaderState.Saver) {
+        VerticalPdfReaderState(resource, isZoomEnable)
+    }
+}


### PR DESCRIPTION
- Divide PDFReader function in VerticalPdfReader and HorizontalPdfReader 
- Improve state handling, now in case of a remote resource or a Base64 pdf if the file has been already generated the state will be saved and restored as a Local resource type, that means the component no longer need to download again the pdf in case of a configuration change. 
- Now will be saved and restored the scroll position as well.