### PR TITLE
Release 1.0.0

### DIFF
--- a/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
@@ -11,9 +11,10 @@ import com.google.accompanist.pager.PagerState
 @OptIn(ExperimentalPagerApi::class)
 class HorizontalPdfReaderState(
     resource: ResourceType,
-    isZoomEnable: Boolean = false,
-    internal val pagerState: PagerState = PagerState()
+    isZoomEnable: Boolean = false
 ) : PdfReaderState(resource, isZoomEnable) {
+
+    internal var pagerState: PagerState = PagerState()
 
     override val currentPage: Int
         get() = pagerState.currentPage
@@ -38,9 +39,10 @@ class HorizontalPdfReaderState(
             restore = {
                 HorizontalPdfReaderState(
                     it[0] as ResourceType,
-                    it[1] as Boolean,
-                    PagerState(currentPage = it[2] as Int)
-                )
+                    it[1] as Boolean
+                ).apply {
+                    pagerState = PagerState(currentPage = it[2] as Int)
+                }
             }
         )
     }

--- a/bouquet/src/main/java/com/rizzi/bouquet/VerticalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/VerticalPdfReaderState.kt
@@ -9,9 +9,11 @@ import androidx.core.net.toUri
 
 class VerticalPdfReaderState(
     resource: ResourceType,
-    isZoomEnable: Boolean = false,
-    internal val lazyState: LazyListState = LazyListState()
+    isZoomEnable: Boolean = false
 ) : PdfReaderState(resource, isZoomEnable) {
+
+    internal var lazyState: LazyListState = LazyListState()
+        private set
 
     override val currentPage: Int
         get() = currentPage()
@@ -57,12 +59,13 @@ class VerticalPdfReaderState(
             restore = {
                 VerticalPdfReaderState(
                     it[0] as ResourceType,
-                    it[1] as Boolean,
+                    it[1] as Boolean
+                ).apply {
                     lazyState = LazyListState(
                         firstVisibleItemIndex = it[2] as Int,
                         firstVisibleItemScrollOffset = it[3] as Int
                     )
-                )
+                }
             }
         )
     }


### PR DESCRIPTION
Move PagerState restore from constructor to a private setter to avoid export accompanist-pager dependency (#6)
- Divide PDFReader function in VerticalPdfReader and HorizontalPdfReader
- Improve state handling, now in case of a remote resource or a Base64 pdf if the file has been already generated the state will be saved and restored as a Local resource type, that means the component no longer need to download again the pdf in case of a configuration change. 
- Now will be saved and restored the scroll position as well.