### PR TITLE
Expose canScroll states in PDFReaderState

### DIFF
--- a/app/src/main/java/com/rizzi/composepdf/MainActivity.kt
+++ b/app/src/main/java/com/rizzi/composepdf/MainActivity.kt
@@ -271,6 +271,42 @@ class MainActivity : ComponentActivity() {
                                 top = 4.dp
                             )
                         )
+                        Text(
+                            text = if (pdfState.canScrollForward) {
+                                "Can scroll forward"
+                            } else {
+                                "Cannot scroll forward"
+                            },
+                            color = if (pdfState.canScrollForward) {
+                                MaterialTheme.colors.onSurface
+                            } else {
+                                MaterialTheme.colors.error
+                            },
+                            modifier = Modifier.padding(
+                                start = 8.dp,
+                                end = 8.dp,
+                                bottom = 8.dp,
+                                top = 4.dp
+                            )
+                        )
+                        Text(
+                            text = if (pdfState.canScrollBackward) {
+                                "Can scroll backward"
+                            } else {
+                                "Cannot scroll backward"
+                            },
+                            color = if (pdfState.canScrollBackward) {
+                                MaterialTheme.colors.onSurface
+                            } else {
+                                MaterialTheme.colors.error
+                            },
+                            modifier = Modifier.padding(
+                                start = 8.dp,
+                                end = 8.dp,
+                                bottom = 8.dp,
+                                top = 4.dp
+                            )
+                        )
                     }
                 }
             }
@@ -334,6 +370,42 @@ class MainActivity : ComponentActivity() {
                                 "Stationary"
                             },
                             color = if (pdfState.isScrolling) {
+                                MaterialTheme.colors.onSurface
+                            } else {
+                                MaterialTheme.colors.error
+                            },
+                            modifier = Modifier.padding(
+                                start = 8.dp,
+                                end = 8.dp,
+                                bottom = 8.dp,
+                                top = 4.dp
+                            )
+                        )
+                        Text(
+                            text = if (pdfState.canScrollForward) {
+                                "Can scroll forward"
+                            } else {
+                                "Cannot scroll forward"
+                            },
+                            color = if (pdfState.canScrollForward) {
+                                MaterialTheme.colors.onSurface
+                            } else {
+                                MaterialTheme.colors.error
+                            },
+                            modifier = Modifier.padding(
+                                start = 8.dp,
+                                end = 8.dp,
+                                bottom = 8.dp,
+                                top = 4.dp
+                            )
+                        )
+                        Text(
+                            text = if (pdfState.canScrollBackward) {
+                                "Can scroll backward"
+                            } else {
+                                "Cannot scroll backward"
+                            },
+                            color = if (pdfState.canScrollBackward) {
                                 MaterialTheme.colors.onSurface
                             } else {
                                 MaterialTheme.colors.error

--- a/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
@@ -18,9 +18,11 @@ class HorizontalPdfReaderState(
     internal var pagerState: PagerState = PagerState()
 
     override val canScrollForward: Boolean
-        get() = pagerState.canScrollForward
+        // Should be using pagerState.canScrollForward but it is not implemented correctly. See PagerState Code.
+        get() = pagerState.currentPage != pagerState.pageCount-1
     override val canScrollBackward: Boolean
-        get() = pagerState.canScrollBackward
+        // Should be using pagerState.canScrollBackward but it is not implemented correctly. See PagerState Code.
+        get() = pagerState.currentPage != 0
 
     override val currentPage: Int
         get() = pagerState.currentPage

--- a/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/HorizontalPdfReaderState.kt
@@ -17,6 +17,11 @@ class HorizontalPdfReaderState(
 
     internal var pagerState: PagerState = PagerState()
 
+    override val canScrollForward: Boolean
+        get() = pagerState.canScrollForward
+    override val canScrollBackward: Boolean
+        get() = pagerState.canScrollBackward
+
     override val currentPage: Int
         get() = pagerState.currentPage
 

--- a/bouquet/src/main/java/com/rizzi/bouquet/PdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/PdfReaderState.kt
@@ -1,5 +1,6 @@
 package com.rizzi.bouquet
 
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -48,6 +49,9 @@ abstract class PdfReaderState(
         get() = mFile != null
 
     abstract val isScrolling: Boolean
+
+    abstract val canScrollForward: Boolean
+    abstract val canScrollBackward: Boolean
 
     fun close() {
         pdfRender?.close()

--- a/bouquet/src/main/java/com/rizzi/bouquet/VerticalPdfReaderState.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/VerticalPdfReaderState.kt
@@ -16,6 +16,10 @@ class VerticalPdfReaderState(
     internal var lazyState: LazyListState = LazyListState()
         private set
 
+    override val canScrollForward: Boolean
+        get() = lazyState.canScrollForward
+    override val canScrollBackward: Boolean
+        get() = lazyState.canScrollBackward
     override val currentPage: Int
         get() = currentPage()
 


### PR DESCRIPTION
Small change to `PDFReaderState` that exposes the `canScrollForward` and `canScrollBackyard` properties from `pagerState` for `HorizontalPDFReaderState` and `lazyListState` for `VerticalPDFReaderState`. 

This is particular useful for supporting this issue: https://github.com/GRizzi91/bouquet/issues/45 as the `currentPage` property would lead to strange scenarios depending on device size, when used to decide if the PDF reader was scrolled to the bottom or top.


https://github.com/GRizzi91/bouquet/assets/16602828/9882124d-96f5-446e-9259-9f1920e456e4

